### PR TITLE
メニュー表示を配列化し三階層までのコントローラ取得に対応

### DIFF
--- a/app/common/functions.php
+++ b/app/common/functions.php
@@ -9,14 +9,18 @@
  *
  * @param string $controllerDir 探索対象のディレクトリ
  * @param string $namespace     現在の名前空間（再帰用）
+ * @param int    $depth         現在の階層（再帰用）
  * @return array<int, array<string, mixed>>
- */
-function get_controller_nav(string $controllerDir, string $namespace = ''): array
+*/
+function get_controller_nav(string $controllerDir, string $namespace = '', int $depth = 0): array
 {
     $nav = [];
 
     $excludeDirs  = defined('EXCLUDE_CONTROLLER_DIRS') ? EXCLUDE_CONTROLLER_DIRS : [];
     $excludeFiles = defined('EXCLUDE_CONTROLLER_FILES') ? EXCLUDE_CONTROLLER_FILES : [];
+
+    // 取得する階層の上限
+    $maxDepth = 3;
 
     try {
         foreach (scandir($controllerDir) as $entry) {
@@ -29,7 +33,11 @@ function get_controller_nav(string $controllerDir, string $namespace = ''): arra
                 if (in_array($entry, $excludeDirs, true)) {
                     continue;
                 }
-                $children = get_controller_nav($path, trim($namespace . '/' . $entry, '/'));
+                // 上限階層を超える場合は再帰処理を行わない
+                if ($depth >= $maxDepth - 1) {
+                    continue;
+                }
+                $children = get_controller_nav($path, trim($namespace . '/' . $entry, '/'), $depth + 1);
                 $nav[] = [
                     'name'       => $entry,
                     'controller' => null,

--- a/app/views/base.twig
+++ b/app/views/base.twig
@@ -1,22 +1,3 @@
-{% macro nav_item(item) %}
-  {% import _self as macros %}
-  {% set has_children = item.children|length > 0 %}
-  <li{% if has_children %} class="dropdown"{% endif %}>
-    {% if item.controller %}
-      <a href="./?c={{ item.controller }}{% if item.namespace %}&n={{ item.namespace }}{% endif %}">{{ item.name|e }}</a>
-    {% else %}
-      <a href="#">{{ item.name|e }}</a>
-    {% endif %}
-    {% if has_children %}
-      <ul class="dropdown-menu">
-        {% for child in item.children %}
-          {{ macros.nav_item(child) }}
-        {% endfor %}
-      </ul>
-    {% endif %}
-  </li>
-{% endmacro %}
-
 <!DOCTYPE html>
 <html lang="ja">
 <head>
@@ -35,11 +16,42 @@
 
   <nav class="site-nav">
     {% block nav %}
-    {% import _self as macros %}
     <ul>
       <li><a href="./">top</a></li>
       {% for item in nav %}
-        {{ macros.nav_item(item) }}
+        <li{% if item.children|length %} class="dropdown"{% endif %}>
+          {% if item.controller %}
+            <a href="./?c={{ item.controller }}{% if item.namespace %}&n={{ item.namespace }}{% endif %}">{{ item.name|e }}</a>
+          {% else %}
+            <a href="#">{{ item.name|e }}</a>
+          {% endif %}
+          {% if item.children|length %}
+            <ul class="dropdown-menu">
+              {% for child in item.children %}
+                <li{% if child.children|length %} class="dropdown"{% endif %}>
+                  {% if child.controller %}
+                    <a href="./?c={{ child.controller }}{% if child.namespace %}&n={{ child.namespace }}{% endif %}">{{ child.name|e }}</a>
+                  {% else %}
+                    <a href="#">{{ child.name|e }}</a>
+                  {% endif %}
+                  {% if child.children|length %}
+                    <ul class="dropdown-menu">
+                      {% for grandchild in child.children %}
+                        <li>
+                          {% if grandchild.controller %}
+                            <a href="./?c={{ grandchild.controller }}{% if grandchild.namespace %}&n={{ grandchild.namespace }}{% endif %}">{{ grandchild.name|e }}</a>
+                          {% else %}
+                            <a href="#">{{ grandchild.name|e }}</a>
+                          {% endif %}
+                        </li>
+                      {% endfor %}
+                    </ul>
+                  {% endif %}
+                </li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        </li>
       {% endfor %}
     </ul>
     {% endblock %}


### PR DESCRIPTION
## 概要
- ナビゲーション取得関数に階層制限を追加し、3階層までのコントローラを探索
- base.twigを配列からメニューを表示する構造に変更

## テスト
- `php -l app/common/functions.php`
- `composer validate --no-check-all`


------
https://chatgpt.com/codex/tasks/task_e_68a5560f156c8330a2434bfbe68a1769