### PR TITLE
vendorディレクトリ未存在時の案内を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ PHPでMVCモデルの構成で簡易的なシステムを作るテンプレー�
 
 1. 依存パッケージのインストール
    ```sh
-   composer update
+   composer install
    ```
 2. 環境変数ファイルの作成
    `sample.env` を `.env` にコピーし、必要に応じて値を編集します。

--- a/public/index.php
+++ b/public/index.php
@@ -2,7 +2,13 @@
 declare(strict_types=1);
 
 session_start();
-require_once __DIR__ . '/../vendor/autoload.php';
+$autoloadPath = __DIR__ . '/../vendor/autoload.php';
+if (!file_exists($autoloadPath)) {
+    http_response_code(500);
+    echo '必要なライブラリが見つかりません。composer install を実行してください。';
+    exit;
+}
+require_once $autoloadPath;
 require_once __DIR__ . '/../config/bootstrap.php';
 
 // Log出力


### PR DESCRIPTION
## 概要
- vendor/autoload.php が存在しない場合にメッセージを表示
- README に `composer install` の手順を追記

## テスト
- `php -l public/index.php`
- `composer install`（403 により失敗）

------
https://chatgpt.com/codex/tasks/task_e_68a563670e08833090cf70ee4b6eeadb