### PR TITLE
c_base.phpをメニューから除外しDEFAULT_CLASSに基づくメニューを生成

### DIFF
--- a/app/views/base.twig
+++ b/app/views/base.twig
@@ -17,11 +17,15 @@
   <nav class="site-nav">
     {% block nav %}
     <ul>
-      <li><a href="./">top</a></li>
       {% for item in nav %}
         <li{% if item.children|length %} class="dropdown"{% endif %}>
           {% if item.controller %}
-            <a href="./?c={{ item.controller }}{% if item.namespace %}&n={{ item.namespace }}{% endif %}">{{ item.name|e }}</a>
+            {% set full = item.namespace ? item.namespace ~ '/' ~ item.controller : item.controller %}
+            {% if full == default_class %}
+              <a href="./">{{ item.name|e }}</a>
+            {% else %}
+              <a href="./?c={{ item.controller }}{% if item.namespace %}&n={{ item.namespace }}{% endif %}">{{ item.name|e }}</a>
+            {% endif %}
           {% else %}
             <a href="#">{{ item.name|e }}</a>
           {% endif %}
@@ -30,7 +34,12 @@
               {% for child in item.children %}
                 <li{% if child.children|length %} class="dropdown"{% endif %}>
                   {% if child.controller %}
-                    <a href="./?c={{ child.controller }}{% if child.namespace %}&n={{ child.namespace }}{% endif %}">{{ child.name|e }}</a>
+                    {% set full_child = child.namespace ? child.namespace ~ '/' ~ child.controller : child.controller %}
+                    {% if full_child == default_class %}
+                      <a href="./">{{ child.name|e }}</a>
+                    {% else %}
+                      <a href="./?c={{ child.controller }}{% if child.namespace %}&n={{ child.namespace }}{% endif %}">{{ child.name|e }}</a>
+                    {% endif %}
                   {% else %}
                     <a href="#">{{ child.name|e }}</a>
                   {% endif %}
@@ -39,7 +48,12 @@
                       {% for grandchild in child.children %}
                         <li>
                           {% if grandchild.controller %}
-                            <a href="./?c={{ grandchild.controller }}{% if grandchild.namespace %}&n={{ grandchild.namespace }}{% endif %}">{{ grandchild.name|e }}</a>
+                            {% set full_grand = grandchild.namespace ? grandchild.namespace ~ '/' ~ grandchild.controller : grandchild.controller %}
+                            {% if full_grand == default_class %}
+                              <a href="./">{{ grandchild.name|e }}</a>
+                            {% else %}
+                              <a href="./?c={{ grandchild.controller }}{% if grandchild.namespace %}&n={{ grandchild.namespace }}{% endif %}">{{ grandchild.name|e }}</a>
+                            {% endif %}
                           {% else %}
                             <a href="#">{{ grandchild.name|e }}</a>
                           {% endif %}

--- a/config/define.php
+++ b/config/define.php
@@ -3,5 +3,7 @@
 const EXCLUDE_CONTROLLER_DIRS = [];
 
 // コントローラ探索時に除外するファイル
-const EXCLUDE_CONTROLLER_FILES = [];
+const EXCLUDE_CONTROLLER_FILES = [
+    'c_base.php',
+];
 

--- a/docs/system_spec.md
+++ b/docs/system_spec.md
@@ -27,6 +27,7 @@
 
 - `config/bootstrap.php` で Monolog を用いたログ設定と Twig 環境の初期化を行います。
 - `app/common/functions.php` の `get_controller_nav()` がコントローラ構成からナビゲーション情報を生成し、Twig のグローバル変数 `nav` として登録します。
+- 基底コントローラ `c_base.php` はメニューから除外されます。
 
 ## エラーハンドリング
 

--- a/public/index.php
+++ b/public/index.php
@@ -12,7 +12,9 @@ $GLOBALS['logger']->info("File : " . __FILE__);
 use Dotenv\Dotenv;
 $dotenv = Dotenv::createImmutable(__DIR__ . '/../');
 $dotenv->load();
-$mustLogin = ($_ENV['MUST_LOGIN'] ?? '1') === '1';
+$mustLogin    = ($_ENV['MUST_LOGIN'] ?? '1') === '1';
+$defaultClass = trim($_ENV['DEFAULT_CLASS'] ?? 'top');
+$GLOBALS['twig']->addGlobal('default_class', $defaultClass);
 
 // URL解析
 $pathInfo = $_SERVER['PATH_INFO'] ?? '';
@@ -31,8 +33,7 @@ $classParam = $_GET['c'] ?? ($parts[0] ?? null);
 $actionParam = $_GET['f'] ?? ($parts[1] ?? null);
 
 if (!isset($classParam) || strlen(trim($classParam)) === 0) {
-    $defaultClass = trim($_ENV['DEFAULT_CLASS'] ?? '');
-    $classParam = $defaultClass !== '' ? $defaultClass : 'top';
+    $classParam = $defaultClass;
 }
 
 if (!isset($actionParam) || strlen(trim($actionParam)) === 0) {


### PR DESCRIPTION
## 概要
- c_base.php をメニュー生成対象から除外
- DEFAULT_CLASS を Twig に共有してトップメニューを環境変数に従って表示

## テスト
- `php -l config/define.php`
- `php -l public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68a56b4174ac83309f12262c18f32d6d